### PR TITLE
Fix token_patterns to respect sentence boundaries and add tests

### DIFF
--- a/diversity/functions.py
+++ b/diversity/functions.py
@@ -42,7 +42,6 @@ def extract_patterns(text: List[str],
     # sentence tokenize then search for patterns in the entire list 
     outputs = sent_tokenize(' '.join(text))
 
-
     # get the part-of-speech patterns (only include top_n patterns)
     joined_pos, tuples  =  get_pos(outputs)
     ngrams_pos  =  token_patterns(joined_pos, n, top_n)

--- a/diversity/functions.py
+++ b/diversity/functions.py
@@ -42,8 +42,6 @@ def extract_patterns(text: List[str],
     # sentence tokenize then search for patterns in the entire list 
     outputs = sent_tokenize(' '.join(text))
 
-    # get the token (word)-level patterns
-    patterns_token  =  token_patterns(outputs, n)
 
     # get the part-of-speech patterns (only include top_n patterns)
     joined_pos, tuples  =  get_pos(outputs)

--- a/diversity/patterns/Token.py
+++ b/diversity/patterns/Token.py
@@ -19,11 +19,11 @@ def token_patterns(
         List[Tuple[str, int]]: Sorted list of top n-gram patterns.
     """
 
-    # treat data as one string 
-    all_data = ' '.join(data)
-
-    ngrams = list(nltk.ngrams(all_data.split(' '), n))
-    frequency = nltk.FreqDist(ngrams)
+    # Iterate to prevent ngrams from crossing sentence boundaries.
+    all_ngrams = []
+    for sentence in data:
+        all_ngrams.extend(list(nltk.ngrams(sentence.split(' '), n)))
+    frequency = nltk.FreqDist(all_ngrams)
 
     sorted_frequency = sorted(frequency.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
 

--- a/tests/token_patterns_test.py
+++ b/tests/token_patterns_test.py
@@ -1,0 +1,99 @@
+import unittest
+from diversity.patterns import Token
+
+
+class TokenPatternsTest(unittest.TestCase):
+
+  def test_returns_empty_list_for_empty_input(self):
+    """Test that empty input returns an empty list."""
+    self.assertEqual(Token.token_patterns([], n=2), [])
+
+  def test_returns_empty_for_sentences_shorter_than_n(self):
+    """Test that sentences shorter than n produce no patterns."""
+    data = ["A B", "C"]
+    n = 3
+    self.assertEqual(Token.token_patterns(data, n), [])
+
+  def test_extracts_unigrams_correctly(self):
+    """Test behavior with n=1 (unigrams)."""
+    data = ["A B C"]
+    n = 1
+    patterns = Token.token_patterns(data, n, top_n=10)
+    patterns_dict = dict(patterns)
+
+    self.assertEqual(patterns_dict.get("A"), 1)
+    self.assertEqual(patterns_dict.get("B"), 1)
+    self.assertEqual(patterns_dict.get("C"), 1)
+
+  def test_counts_pattern_frequencies_correctly(self):
+    """Test that it correctly counts multiple occurrences of the same pattern."""
+    data = ["A B C", "A B D"]
+    n = 2
+    patterns = Token.token_patterns(data, n, top_n=10)
+    patterns_dict = dict(patterns)
+
+    # "A B" appears twice
+    self.assertEqual(patterns_dict.get("A B"), 2)
+    # "B C" appears once
+    self.assertEqual(patterns_dict.get("B C"), 1)
+
+  def test_does_not_cross_sentence_boundaries(self):
+    """Test that patterns are not formed across sentence boundaries.
+
+    This verifies the fix for the bug where patterns like 'C D' were incorrectly
+    generated from input ["A B C", "D E F"].
+    """
+    # Two sentences that, if joined directly, would create "C D"
+    data = ["A B C", "D E F"]
+    n = 2
+
+    # "C D" should NOT appear if boundaries are respected
+    patterns = Token.token_patterns(data, n, top_n=10)
+    pattern_strings = [p[0] for p in patterns]
+
+    self.assertNotIn("C D", pattern_strings)
+    self.assertIn("A B", pattern_strings)
+    self.assertIn("B C", pattern_strings)
+    self.assertIn("D E", pattern_strings)
+    self.assertIn("E F", pattern_strings)
+
+  def test_sorts_patterns_by_frequency_descending(self):
+    """Test that patterns are returned in descending order of frequency."""
+    data = ["A B", "C D", "C D", "E F", "E F", "E F"]
+    n = 2
+    patterns = Token.token_patterns(data, n, top_n=10)
+
+    self.assertEqual(patterns[0], ("E F", 3))
+    self.assertEqual(patterns[1], ("C D", 2))
+    self.assertEqual(patterns[2], ("A B", 1))
+
+  def test_truncates_results_to_top_n(self):
+    """Test that the result is limited to top_n items."""
+    # Create 3 distinct patterns: "A B" (3x), "C D" (2x), "E F" (1x)
+    data = ["A B", "A B", "A B", "C D", "C D", "E F"]
+    n = 2
+
+    # Limit to top 2
+    patterns = Token.token_patterns(data, n, top_n=2)
+
+    self.assertEqual(len(patterns), 2)
+    self.assertEqual(patterns[0], ("A B", 3))
+    self.assertEqual(patterns[1], ("C D", 2))
+
+  def test_respects_case_and_whitespace(self):
+    """Test that tokenization is specific (space split) and case sensitive."""
+    data = ["The cat", "the Cat"]
+    n = 1
+    patterns = Token.token_patterns(data, n, top_n=10)
+    patterns_dict = dict(patterns)
+
+    # "The" and "the" are distinct
+    self.assertEqual(patterns_dict.get("The"), 1)
+    self.assertEqual(patterns_dict.get("the"), 1)
+    # "cat" and "Cat" are distinct
+    self.assertEqual(patterns_dict.get("cat"), 1)
+    self.assertEqual(patterns_dict.get("Cat"), 1)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Fix token_patterns to respect sentence boundaries

## Summary
This PR fixes a critical bug in `token_patterns` where n-grams were incorrectly computed across sentence boundaries.

## Problem
Previously, `token_patterns` (in `diversity/patterns/Token.py`) operated by joining all input strings (sentences) into a single massive string before computing n-grams:

```python
all_data = ' '.join(data)
ngrams = list(nltk.ngrams(all_data.split(' '), n))
```

This caused the n-grams to ignore sentence boundaries. For example, the last word of one sentence and the first word of the next sentence would form an n-gram. This led to the generation of invalid patterns, such as the Part-of-Speech (POS) n-gram `"Noun . Noun"` appearing as a very frequent pattern (where the `.` is the sentence end token).

## Inconsistency with Other Code
This behavior was inconsistent with how patterns are handled in other parts of the codebase, specifically in `pos_patterns` (in `diversity/patterns/part_of_speech.py`). 

In `diversity/functions.py`, the text is first split into sentences using `sent_tokenize`. The `pos_patterns` function then searches for pattern matches on a **per-sentence basis** (iterating over the list of tokenized sentences). 

Because `token_patterns` ignored sentence boundaries when *generating* top patterns, it would produce patterns that spanned across sentences. However, `pos_patterns` would then fail to find these patterns because it only looked *within* individual sentences. This created a disconnect between pattern generation and pattern matching.

## Solution
The implementation of `token_patterns` has been refactored to:
1.  Iterate through each sentence independently.
2.  Compute n-grams for each sentence.
3.  Aggregate all n-grams into a single frequency distribution.

This ensures strict respect for sentence boundaries, matching the behavior expected by `pos_patterns`.

## Changes
*   **`diversity/patterns/Token.py`**: Refactored `token_patterns` to process sentences independently.
*   **`diversity/functions.py`**: Removed unused `patterns_token` assignment.
*   **`tests/token_patterns_test.py`**: Added new unit tests.

## Verification Results
I added 8 new unit tests in `tests/token_patterns_test.py` and they all passed successfully:
```
........
----------------------------------------------------------------------
Ran 8 tests in 0.000s

OK
```

## Note
This change corresponds to internal Google CL/859151081.

