### PR TITLE
Fix whitespace stripping in pos_patterns and add tests

### DIFF
--- a/diversity/patterns/part_of_speech.py
+++ b/diversity/patterns/part_of_speech.py
@@ -66,19 +66,16 @@ def pos_patterns(
         pos.append([i[1] for i in doc])
         word.append([i[0] for i in doc])
     
-    pos = [' '.join(x) for x in pos]
-    word = [' '.join(x) for x in word]
-
     all_matches = [] 
 
     # return positions of each tag and the corresponding tokens
     for w, p in zip(word, pos):
 
-        test = _find_sub_list(pattern.split(), p.split())
+        test = _find_sub_list(pattern.split(), p)
 
         if test:
             for occ in test: 
-                splits = w.split()[int(occ[0]):int(occ[1]+1)]
+                splits = w[int(occ[0]):int(occ[1]+1)]
                 all_matches.append(" ".join(splits))
 
     return set(all_matches) 

--- a/tests/part_of_speech_test.py
+++ b/tests/part_of_speech_test.py
@@ -1,0 +1,86 @@
+from typing import List, Tuple
+import unittest
+from diversity.patterns import part_of_speech
+
+
+# Mock data for unit testing pos_patterns without SpaCy
+def create_pos_tuples(
+    sentences: List[str], tags: List[str]
+) -> List[List[Tuple[str, str]]]:
+  result = []
+  words = [s.split() for s in sentences]
+  tag_lists = [t.split() for t in tags]
+  for w_list, t_list in zip(words, tag_lists):
+    result.append(list(zip(w_list, t_list)))
+  return result
+
+
+class PartOfSpeechTest(unittest.TestCase):
+
+  def test_pos_patterns_basic(self):
+    text = [["The", "quick", "fox"]]
+    tags = [["DT", "JJ", "NN"]]
+    data = [[(w, t) for w, t in zip(text[0], tags[0])]]
+
+    matches = part_of_speech.pos_patterns(data, "DT JJ NN")
+    self.assertEqual(matches, {"The quick fox"})
+
+  def test_pos_patterns_no_match(self):
+    text = [["The", "quick", "fox"]]
+    tags = [["DT", "JJ", "NN"]]
+    data = [[(w, t) for w, t in zip(text[0], tags[0])]]
+
+    matches = part_of_speech.pos_patterns(data, "NN NN")
+    self.assertEqual(matches, set())
+
+  def test_pos_patterns_partial_match(self):
+    sentences = ["The quick brown fox"]
+    tags = ["DT JJ NN NN"]
+    data = create_pos_tuples(sentences, tags)
+
+    matches = part_of_speech.pos_patterns(data, "JJ NN")
+    self.assertIn("quick brown", matches)
+    matches = part_of_speech.pos_patterns(data, "NN NN")
+    self.assertIn("brown fox", matches)
+
+  def test_pos_patterns_multiple_occurrences(self):
+    sentences = ["A cat and a dog"]
+    tags = ["DT NN CC DT NN"]
+    data = create_pos_tuples(sentences, tags)
+
+    matches = part_of_speech.pos_patterns(data, "DT NN")
+    self.assertEqual(matches, {"A cat", "a dog"})
+
+  def test_pos_patterns_with_newline(self):
+    # Manually construct data because create_pos_tuples uses split() which
+    # removes newlines
+    data = [[("A", "DT"), ("\n", "SPACE"), ("B", "NN")]]
+
+    matches = part_of_speech.pos_patterns(data, "DT SPACE NN")
+    self.assertEqual(matches, {"A \n B"})
+
+  def test_pos_patterns_cross_document_boundary(self):
+    # Doc 1: "The cat" (DT NN)
+    # Doc 2: "sat on" (VBD IN)
+    data = [[("The", "DT"), ("cat", "NN")], [("sat", "VBD"), ("on", "IN")]]
+    matches = part_of_speech.pos_patterns(data, "NN VBD")
+    self.assertEqual(matches, set())
+
+  def test_pos_patterns_long_sequence(self):
+    data = [[
+        ("A", "DT"),
+        ("\n", "SPACE"),
+        ("long", "JJ"),
+        ("\t", "SPACE"),
+        ("sentence", "NN"),
+        ("with", "IN"),
+        ("many", "JJ"),
+        ("words", "NNS"),
+        (".", "."),
+    ]]
+    matches = part_of_speech.pos_patterns(data, "JJ SPACE NN")
+    self.assertEqual(matches, {"long \t sentence"})
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Fix whitespace stripping in pos_patterns

## Summary
This PR fixes a bug in `pos_patterns` where whitespace-only tokens (like newlines `\n`) were inadvertently stripped, causing an index mismatch between tokens and their corresponding Part-of-Speech (POS) tags.

## Problem
In `pos_patterns` (in `diversity/patterns/part_of_speech.py`), the code was converting token lists to strings and then using `.split()` to process them:

```python
test = _find_sub_list(pattern.split(), p.split())
...
splits = w.split()[int(occ[0]):int(occ[1]+1)]
```

This operation removed whitespace-only tokens (like newlines `\n` or tabs `\t`). However, the corresponding list of POS tags preserved these whitespace tokens. When a pattern matched a tag, it would attempt to retrieve the token at the same index from the filtered list, leading to incorrect token extraction or truncated results.

## Solution
The implementation of `pos_patterns` has been refactored to operate directly on the lists of tokens and tags without joining and splitting them as strings. This ensures that all tokens, including whitespace, are preserved and indices remain aligned.

## Changes
*   **`diversity/patterns/part_of_speech.py`**: Refactored `pos_patterns` to work on lists directly.
*   **`tests/part_of_speech_test.py`**: Added new unit tests covering edge cases with whitespace.

## Verification Results
I added 7 new unit tests in `tests/part_of_speech_test.py` and they all passed successfully:
```
.......
----------------------------------------------------------------------
Ran 7 tests in 0.000s

OK
```

## Note
This change corresponds to internal Google CL/859746433.
